### PR TITLE
Fix undefined variable destFile

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ const compressGostScript = async(outputFile,inputFile) => {
           console.log('exec error: ' + error);
           reject(error);
         }
-        resolve(destFile);
+        resolve(outputFile);
       });
   });
 }


### PR DESCRIPTION
Hi there,

Awesome blogpost :tada:. I love the usage of `sam` to develop the lambda function locally.
When trying to make this work on my local environment I came across an error. This PR should fix that. 

### What has been done:
- Replaced variable `destFile` with `outputFile`

### How to test:
- Run current application, notice how it fails invoking with an error: `ReferenceError: destFile is not defined`
- Checkout PR
- Try to re-run the application, notice how it now succeeds 

### Notes:
- I had to add a bit of configuration to my AWS.S3 instance. Did you solve this differently? 

```javascript
const S3 = new AWS.S3({
  signatureVersion: 'v4',
  accessKeyId: '',
  secretAccessKey: ''
});

```